### PR TITLE
fix: v4 per-panel Pin/Vin/Iin null (aggregate-column row selection) — #7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [2.0.2] - 2026-07-01
+
+### Fixed
+- Per-panel `Pin`/`Vin`/`Iin` (and `system.power_w`) stuck `unavailable` on the
+  v4 API for Premium / `sensors=true` accounts, while per-panel energy worked
+  ([#7](https://github.com/Bobsilvio/tigosolar-online/issues/7)).
+  Root cause: `_apply_summary` selected a single "newest row where *any* column
+  is non-dash", but the trailing CCA/aggregate columns are non-dash in every
+  minute of the day, so selection always walked to the empty end-of-day row and
+  every panel collapsed to `null`. This is the same class of bug the 2.0.1 fix
+  addressed for the v3 CSV path, left unfixed on v4. Fixed by scanning per
+  panel column for its latest non-dash value, ignoring the aggregate columns.
+
+### Added
+- Verbose-gated diagnostics for the summary telemetry layout (`SUMMARY-SHAPE`,
+  `EQUIPMENT-ORDER`) to correlate `d[]` columns with the equipment topology.
+
 ## [2.0.1] - 2026-06-13
 
 ### Fixed

--- a/custom_components/tigo/coordinator.py
+++ b/custom_components/tigo/coordinator.py
@@ -395,11 +395,57 @@ class TigoDataUpdateCoordinator(DataUpdateCoordinator):
                     self._meta.last_lastdata = last_data
                 self._apply_summary(metric, payload)
 
+    def _debug_summary_shape(self, metric: str, rows: list) -> None:
+        """Compact DEBUG dump of the summary d[] layout vs. the topology.
+
+        The full-day payload is ~330 KB, so log_raw truncates it to the
+        (empty) night rows. This logs only the richest row plus the
+        index->equipment_id map, so users can confirm whether per-panel
+        columns are populated and aligned. Issue #7.
+        """
+        if not _LOGGER.isEnabledFor(logging.DEBUG) or self.topology is None:
+            return
+        best: list | None = None
+        best_t = ""
+        best_cnt = -1
+        for row in rows:
+            d = row.get("d") or []
+            cnt = sum(1 for v in d if v not in ("-", "", None))
+            if cnt > best_cnt:
+                best_cnt, best, best_t = cnt, d, row.get("t", "")
+        if best is None:
+            _LOGGER.debug("SUMMARY-SHAPE[%s]: no rows", metric)
+            return
+        n_idx = len(self.topology.by_index)
+        max_idx = max(self.topology.by_index, default=-1)
+        filled = [(i, v) for i, v in enumerate(best) if v not in ("-", "", None)]
+        # For each filled column: does it map to a panel? (else aggregate/skipped)
+        mapped = [
+            (i, v, self.topology.by_index[i].equipment_id)
+            for i, v in filled
+            if i in self.topology.by_index
+        ]
+        unmapped = [(i, v) for i, v in filled if i not in self.topology.by_index]
+        _LOGGER.debug(
+            "SUMMARY-SHAPE[%s]: richest t=%s len(d)=%d non_dash=%d | "
+            "by_index: panels=%d max_idx=%d | "
+            "filled->panel=%s | filled->UNMAPPED(aggregate?)=%s",
+            metric,
+            best_t,
+            len(best),
+            best_cnt,
+            n_idx,
+            max_idx,
+            mapped[:50],
+            unmapped[:50],
+        )
+
     def _apply_summary(self, metric: str, payload: dict) -> None:
         dataset = payload.get("dataset") or []
         if not dataset:
             return
         rows = dataset[0].get("data") or []
+        self._debug_summary_shape(metric, rows)
         seen = self._last_minute.get(metric, -1)
         newest = seen
         newest_row: list | None = None

--- a/custom_components/tigo/coordinator.py
+++ b/custom_components/tigo/coordinator.py
@@ -168,7 +168,6 @@ class TigoDataUpdateCoordinator(DataUpdateCoordinator):
 
         self._meta = _RuntimeMeta()
         self._backoff = _Backoff()
-        self._last_minute: dict[str, int] = {}
         self._panel_vals: dict[str, dict[str, float | None]] = {}
         self._sys_energy = _EnergyState()
         self._panel_energy: dict[str, _EnergyState] = {}
@@ -305,7 +304,6 @@ class TigoDataUpdateCoordinator(DataUpdateCoordinator):
             self._sys_energy.rollover()
             for st in self._panel_energy.values():
                 st.rollover()
-            self._last_minute.clear()
             self._meta.last_lastdata = None
             await self._refresh_system_info(today)
             self._meta.current_date = date_str
@@ -446,28 +444,41 @@ class TigoDataUpdateCoordinator(DataUpdateCoordinator):
             return
         rows = dataset[0].get("data") or []
         self._debug_summary_shape(metric, rows)
-        seen = self._last_minute.get(metric, -1)
-        newest = seen
-        newest_row: list | None = None
+        assert self.topology is not None
+
+        # Per-panel-column latest-valid selection (issue #7). The old code
+        # picked ONE newest row where *any* column was non-dash, then mapped
+        # its whole d[]. But the trailing CCA/aggregate columns (indices >=
+        # len(by_index)) are non-dash in every minute of the day -- including
+        # night and not-yet-reached minutes -- so "newest such row" always
+        # walked to the end-of-day row, where the per-panel columns are still
+        # "-", collapsing every panel to null. This is the same failure the
+        # v2.0.1 changelog fixed for the v3 CSV path, unfixed here.
+        #
+        # Fix: scan every row and, per panel column, keep the highest-minute
+        # non-dash value. Only panel indices (by_index) are considered, so the
+        # always-fresh aggregate columns can't hijack selection.
+        latest: dict[int, tuple[int, Any]] = {}
         for row in rows:
             mi = self._minute_index(row.get("t", ""))
-            if mi <= seen:
+            if mi < 0:
                 continue
             vals = row.get("d") or []
-            if any(v not in ("-", "", None) for v in vals):
-                if mi > newest:
-                    newest = mi
-                    newest_row = vals
-        if newest_row is None:
-            return  # no newer filled minute -> carry forward
-        self._last_minute[metric] = newest
-        assert self.topology is not None
-        for idx, raw in enumerate(newest_row):
-            meta = self.topology.by_index.get(idx)
-            if meta is None:
-                continue
+            for idx in self.topology.by_index:
+                if idx >= len(vals):
+                    continue
+                raw = vals[idx]
+                if raw in ("-", "", None):
+                    continue
+                prev = latest.get(idx)
+                if prev is None or mi > prev[0]:
+                    latest[idx] = (mi, raw)
+        if not latest:
+            return  # nothing populated yet today -> carry forward
+        for idx, (_mi, raw) in latest.items():
+            meta = self.topology.by_index[idx]
             try:
-                val = None if raw in ("-", "", None) else round(float(raw), 2)
+                val = round(float(raw), 2)
             except (TypeError, ValueError):
                 val = None
             self._panel_vals.setdefault(meta.equipment_id, {})[metric] = val

--- a/custom_components/tigo/manifest.json
+++ b/custom_components/tigo/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/TerryFrench/tigosolar-online/issues",
   "loggers": ["custom_components.tigo"],
   "requirements": [],
-  "version": "2.0.1"
+  "version": "2.0.2"
 }

--- a/custom_components/tigo/topology.py
+++ b/custom_components/tigo/topology.py
@@ -194,4 +194,12 @@ def build_topology(layout: dict, equipments: list[dict]) -> Topology:
         len(topo.inverters),
         topo.cca_uids,
     )
+    if _LOGGER.isEnabledFor(logging.DEBUG):
+        # Full equipment order so the summary d[] columns can be correlated
+        # (the d[] index == this enumerate index). Issue #7.
+        order = [
+            (i, e.get("equipmentId"), (e.get("equipmentType") or "").lower())
+            for i, e in enumerate(equipments)
+        ]
+        _LOGGER.debug("EQUIPMENT-ORDER (d[] index -> id/type): %s", order)
     return topo


### PR DESCRIPTION
Fixes #7.

## Problem

On the v4 API, Premium / `sensors=true` accounts got `unavailable` per-panel `Pin`/`Vin`/`Iin` and `system.power_w`, while per-panel **energy** worked.

## Root cause

Confirmed with a debug build's `SUMMARY-SHAPE` log (thanks @montemartello73): the summary `d[]` array is correctly aligned — columns `0..37` are the 38 panels, columns `38..43` are 6 CCA/aggregate channels absent from `/equipments`. Panel columns **are** populated during production.

The bug was **row selection** in `_apply_summary`: it picked the single highest-minute row where *any* column was non-dash, then mapped that whole row. The aggregate columns are non-dash in **every** minute of the day (night and not-yet-reached minutes included), so that predicate holds for all 1440 rows and selection always walked to the end-of-day row — where the panel columns are still `-` — collapsing every panel to `null`. Energy was unaffected because it comes from the `aggenergy` dict keyed by `object_id`.

This is the same class of bug the 2.0.1 changelog fixed on the v3 CSV path (`parse_param_csv`), left unfixed on v4.

## Fix

Scan every row and, **per panel column** (`by_index` only, so the always-fresh aggregate columns can't hijack selection), keep the highest-minute non-dash value. Verified against a simulated 44-column day: 38/38 panels recover their latest real reading vs. all-null before.

## Changes

- `coordinator._apply_summary`: per-panel-column latest-valid selection; removed dead `_last_minute` bookkeeping.
- Kept verbose-gated `SUMMARY-SHAPE` / `EQUIPMENT-ORDER` diagnostics (useful for future telemetry-shape debugging).
- CHANGELOG + version bump to 2.0.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)